### PR TITLE
Updated MongoDB function names

### DIFF
--- a/nexoan/crud-api/db/repository/mongo/metadata_handler.go
+++ b/nexoan/crud-api/db/repository/mongo/metadata_handler.go
@@ -12,15 +12,15 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-// Add this function to handle metadata operations
+// HandleMetadata inserts or updates the metadata of an entity
 func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string, entity *pb.Entity) error {
-	// Skip operations if no metadata is provided
+	// Skip if no metadata is provided
 	if entity == nil || entity.GetMetadata() == nil || len(entity.GetMetadata()) == 0 {
 		return nil
 	}
 
 	// Check if entity exists
-	existingEntity, err := repo.ReadEntity(ctx, entityId)
+	existingEntity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil && err != mongo.ErrNoDocuments {
 		return err
 	}
@@ -37,12 +37,12 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 			Attributes:    entity.Attributes,
 			Relationships: entity.Relationships,
 		}
-		_, err = repo.CreateEntity(ctx, newEntity)
+		_, err = repo.CreateMetadata(ctx, newEntity)
 	} else {
 		// Update existing entity's metadata
 		// TODO: Should we choose _id for placing our id or should we use id field separately and use that.
 		// Because then it is going to be reading or deleting or whatever by filtering using an attribute not the id of the object.
-		_, err = repo.UpdateEntity(ctx, existingEntity.Id, bson.M{"metadata": entity.GetMetadata()})
+		_, err = repo.UpdateMetadata(ctx, existingEntity.Id, bson.M{"metadata": entity.GetMetadata()})
 	}
 
 	return err
@@ -50,11 +50,11 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 
 // Improved GetMetadata function that handles conversion internally
 func (repo *MongoRepository) GetMetadata(ctx context.Context, entityId string) (map[string]*anypb.Any, error) {
-	// Use the existing ReadEntity method for consistency
-	entity, err := repo.ReadEntity(ctx, entityId)
+	// Use the existing ReadMetadata method for consistency
+	entity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil {
 		// Log error and return empty metadata map
-		log.Printf("Error retrieving metadata for entity %s: %v", entityId, err)
+			log.Printf("Error retrieving metadata for entity %s: %v", entityId, err)
 		metadata := make(map[string]*anypb.Any)
 		return metadata, nil
 	}

--- a/nexoan/crud-api/db/repository/mongo/mongodb_client.go
+++ b/nexoan/crud-api/db/repository/mongo/mongodb_client.go
@@ -73,15 +73,15 @@ func (repo *MongoRepository) collection() *mongo.Collection {
 
 // CreateEntity inserts a new entity in MongoDB
 // FIXME: https://github.com/LDFLK/nexoan/issues/118
-func (repo *MongoRepository) CreateEntity(ctx context.Context, entity *pb.Entity) (*mongo.InsertOneResult, error) {
+func (repo *MongoRepository) CreateMetadata(ctx context.Context, entity *pb.Entity) (*mongo.InsertOneResult, error) {
 	// Use the entity.Id as MongoDB's _id field
 	doc := toDocument(entity)
 	result, err := repo.collection().InsertOne(ctx, doc)
 	return result, err
 }
 
-// ReadEntity fetches an entity by ID from MongoDB
-func (repo *MongoRepository) ReadEntity(ctx context.Context, id string) (*pb.Entity, error) {
+// ReadMetadata fetches an entity by ID from MongoDB
+func (repo *MongoRepository) ReadMetadata(ctx context.Context, id string) (*pb.Entity, error) {
 	var doc entityDocument
 	err := repo.collection().FindOne(ctx, bson.M{"_id": id}).Decode(&doc)
 	if err != nil {
@@ -90,15 +90,15 @@ func (repo *MongoRepository) ReadEntity(ctx context.Context, id string) (*pb.Ent
 	return fromDocument(&doc), nil
 }
 
-// UpdateEntity updates an entity's attributes in MongoDB
-func (repo *MongoRepository) UpdateEntity(ctx context.Context, id string, updates bson.M) (*mongo.UpdateResult, error) {
+// UpdateMetadata updates an entity's attributes in MongoDB
+func (repo *MongoRepository) UpdateMetadata(ctx context.Context, id string, updates bson.M) (*mongo.UpdateResult, error) {
 	update := bson.M{"$set": updates}
 	result, err := repo.collection().UpdateOne(ctx, bson.M{"_id": id}, update)
 	return result, err
 }
 
 // DeleteEntity removes an entity from MongoDB
-func (repo *MongoRepository) DeleteEntity(ctx context.Context, id string) (*mongo.DeleteResult, error) {
+func (repo *MongoRepository) DeleteMetadata(ctx context.Context, id string) (*mongo.DeleteResult, error) {
 	result, err := repo.collection().DeleteOne(ctx, bson.M{"_id": id})
 	return result, err
 }

--- a/nexoan/crud-api/db/repository/mongo/mongodb_client_test.go
+++ b/nexoan/crud-api/db/repository/mongo/mongodb_client_test.go
@@ -93,13 +93,13 @@ func TestCreateAndReadEntity(t *testing.T) {
 	}
 
 	// Create entity
-	result, err := testRepo.CreateEntity(testCtx, entity)
+	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 	log.Printf("Inserted document with ID: %v", result.InsertedID)
 
 	// Read entity with error check
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	if err != nil {
 		t.Fatalf("Failed to read entity: %v", err)
 	}
@@ -143,7 +143,7 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	}
 
 	// Create entity
-	_, err = testRepo.CreateEntity(testCtx, entity)
+	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
 	// Update metadata
@@ -156,16 +156,14 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	updatedMetadata["key3"] = val3 // Add new key
 
 	// Update entity
-	_, err = testRepo.UpdateEntity(testCtx, entityID, map[string]interface{}{
+	_, err = testRepo.UpdateMetadata(testCtx, entityID, map[string]interface{}{
 		"metadata": updatedMetadata,
 	})
 	assert.NoError(t, err)
 
 	// Read updated entity
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
-
-	// Verify updated metadata
 	assert.Equal(t, 2, len(readEntity.Metadata))
 	assert.Contains(t, readEntity.Metadata, "key1")
 	assert.Contains(t, readEntity.Metadata, "key3")
@@ -198,16 +196,16 @@ func TestDeleteEntity(t *testing.T) {
 	}
 
 	// Create entity
-	_, err = testRepo.CreateEntity(testCtx, entity)
+	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
 	// Delete entity
-	result, err := testRepo.DeleteEntity(testCtx, entityID)
+	result, err := testRepo.DeleteMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), result.DeletedCount)
 
 	// Verify entity is deleted
-	_, err = testRepo.ReadEntity(testCtx, entityID)
+	_, err = testRepo.ReadMetadata(testCtx, entityID)
 	assert.Error(t, err) // Should return an error since entity doesn't exist
 }
 
@@ -223,8 +221,6 @@ func TestMetadataHandling(t *testing.T) {
 
 	// Create test entity with metadata
 	entityID := "test-entity-4"
-
-	// Create diverse metadata with different value types
 	metadata := make(map[string]*anypb.Any)
 
 	stringVal, err := anypb.New(wrapperspb.String("string-value"))
@@ -247,12 +243,12 @@ func TestMetadataHandling(t *testing.T) {
 	}
 
 	// Create entity - this should use the entityID as the document ID
-	result, err := testRepo.CreateEntity(testCtx, entity)
+	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 
 	// Read entity to verify metadata was stored correctly
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 
 	// Verify metadata with different value types


### PR DESCRIPTION
# Updated MongoDB Function Names(issue #340)

## Description
This PR renames MongoDB client, handler, and test functions to better reflect that they operate on **metadata** instead of entire entities. 

## Changes
- `CreateEntity` → `CreateMetadata`
- `ReadEntity` → `ReadMetadata`
- `UpdateEntity` → `UpdateMetadata`
- `DeleteEntity` → `DeleteMetadata`
- Updated handler and test files to use the new names
- Improves code readability and aligns naming with purpose
-  Functionality remains unchanged

