### PR TITLE
GH-440: Postgres table name can exceed character limit

### DIFF
--- a/opengin/core-api/db/repository/postgres/data_handler.go
+++ b/opengin/core-api/db/repository/postgres/data_handler.go
@@ -394,8 +394,9 @@ func isTypeCompatible(existingType, newType typeinference.DataType) bool {
 
 // handleTabularData processes tabular data attributes
 func (repo *PostgresRepository) HandleTabularData(ctx context.Context, entityID, attrName string, value *pb.TimeBasedValue, schemaInfo *schema.SchemaInfo) error {
-	// Generate table name - with 41 chars
+	// Generate table name - UUID without hyphens (32 chars) + prefix (5 chars) = 37 chars total
 	unique_id := uuid.New().String()
+	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for PostgreSQL compatibility
 	tableName := fmt.Sprintf("attr_%s", unique_id)
 
 	// Convert schema to columns

--- a/opengin/core-api/db/repository/postgres/data_handler.go
+++ b/opengin/core-api/db/repository/postgres/data_handler.go
@@ -14,6 +14,7 @@ import (
 
 	commons "lk/datafoundation/core-api/commons"
 
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -393,8 +394,9 @@ func isTypeCompatible(existingType, newType typeinference.DataType) bool {
 
 // handleTabularData processes tabular data attributes
 func (repo *PostgresRepository) HandleTabularData(ctx context.Context, entityID, attrName string, value *pb.TimeBasedValue, schemaInfo *schema.SchemaInfo) error {
-	// Generate table name
-	tableName := fmt.Sprintf("attr_%s_%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attrName))
+	// Generate table name - with 41 chars
+	unique_id := uuid.New().String()
+	tableName := fmt.Sprintf("attr_%s", unique_id)
 
 	// Convert schema to columns
 	columns := schemaToColumns(schemaInfo)

--- a/opengin/core-api/engine/attribute_resolver.go
+++ b/opengin/core-api/engine/attribute_resolver.go
@@ -197,7 +197,7 @@ func (p *EntityAttributeProcessor) ProcessEntityAttributes(ctx context.Context, 
 func (p *EntityAttributeProcessor) handleAttributeLookUp(ctx context.Context, entityID, attrName string, storageType storageinference.StorageType, operation string, startTime time.Time) error {
 	// Generate attribute metadata
 	fmt.Printf("DEBUG: Handling graph metadata for attribute %s\n", attrName)
-	attributeID := GenerateAttributeID(entityID, attrName)
+	attributeID := GenerateAttributeID()
 	storagePath := GenerateStoragePath(entityID, attrName, storageType)
 
 	metadata := &AttributeMetadata{

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"lk/datafoundation/core-api/commons"
@@ -441,12 +442,14 @@ func GetDatasetType(storageType storageinference.StorageType) string {
 // GenerateAttributeID generates a unique ID for an attribute
 func GenerateAttributeRelationshipID() string {
 	unique_id := uuid.New().String()
+	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
 	return fmt.Sprintf("attr_rel_%s", unique_id)
 }
 
 func GenerateAttributeID() string {
 	// attribute name should be unique within an entity
 	unique_id := uuid.New().String()
+	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
 	return fmt.Sprintf("attr_%s", unique_id)
 }
 

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -11,6 +11,7 @@ import (
 	pb "lk/datafoundation/core-api/lk/datafoundation/core-api"
 	"lk/datafoundation/core-api/pkg/storageinference"
 
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
@@ -139,7 +140,7 @@ func (g *GraphMetadataManager) createAttributeLookUpGraph(ctx context.Context, m
 	// the relationships map needs a unique key for each relationship
 	// since the attribute id and the name of the attribute is unique for each attribute
 	// among all entities, we can use this to form a unique key for the relationship
-	relationshipId := GenerateAttributeRelationshipID(metadata.EntityID, metadata.AttributeName)
+	relationshipId := GenerateAttributeRelationshipID()
 
 	parentNode := &pb.Entity{
 		Id:         metadata.EntityID,
@@ -232,7 +233,7 @@ func MakeMetadataOfAttributeMetadata(metadata *AttributeMetadata) map[string]*an
 // MakeRelationshipProto creates a Relationship protobuf object for IS_ATTRIBUTE relationship
 func MakeRelationshipFromAttributeMetadata(metadata *AttributeMetadata) *pb.Relationship {
 	return &pb.Relationship{
-		Id:              GenerateAttributeRelationshipID(metadata.EntityID, metadata.AttributeName),
+		Id:              GenerateAttributeRelationshipID(),
 		RelatedEntityId: metadata.AttributeID,
 		Name:            IS_ATTRIBUTE_RELATIONSHIP,
 		StartTime:       metadata.Created.Format(time.RFC3339),
@@ -438,13 +439,15 @@ func GetDatasetType(storageType storageinference.StorageType) string {
 }
 
 // GenerateAttributeID generates a unique ID for an attribute
-func GenerateAttributeRelationshipID(entityID, attributeName string) string {
-	return fmt.Sprintf("%s_is_attribute_of_%s", attributeName, entityID)
+func GenerateAttributeRelationshipID() string {
+	unique_id := uuid.New().String()
+	return fmt.Sprintf("attr_rel_%s", unique_id)
 }
 
-func GenerateAttributeID(entityID, attributeName string) string {
+func GenerateAttributeID() string {
 	// attribute name should be unique within an entity
-	return fmt.Sprintf("%s_attr_%s", entityID, attributeName)
+	unique_id := uuid.New().String()
+	return fmt.Sprintf("attr_%s", unique_id)
 }
 
 // GenerateStoragePath generates a storage path for an attribute

--- a/opengin/core-api/engine/graph_metadata_test.go
+++ b/opengin/core-api/engine/graph_metadata_test.go
@@ -90,15 +90,6 @@ func TestDatasetTypeMapping(t *testing.T) {
 	}
 }
 
-// TestAttributeIDGeneration tests the attribute ID generation
-func TestAttributeIDGeneration(t *testing.T) {
-	entityID := "engine-test-entity-123"
-	attributeName := "user_profile"
-
-	attributeID := GenerateAttributeID(entityID, attributeName)
-	expectedID := "engine-test-entity-123_attr_user_profile"
-	assert.Equal(t, expectedID, attributeID)
-}
 
 // TestStoragePathGeneration tests the storage path generation
 func TestStoragePathGeneration(t *testing.T) {

--- a/opengin/core-api/go.mod
+++ b/opengin/core-api/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.24.1
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
 	github.com/neo4j/neo4j-go-driver/v5 v5.28.0
 	github.com/stretchr/testify v1.10.0


### PR DESCRIPTION
This pr closes #440. 

Postgres table names are now generated using uuid such that they never exceed postgres' table name character limit.