### PR TITLE
GH-469: [ATTRIBUTES] Duplicate attribute tables with the same name created

### DIFF
--- a/opengin/core-api/cmd/server/service.go
+++ b/opengin/core-api/cmd/server/service.go
@@ -81,8 +81,15 @@ func (s *Server) CreateEntity(ctx context.Context, req *pb.Entity) (*pb.Entity, 
 	}
 
 	if hasErrors {
-		log.Printf("[server.CreateEntity] Some attributes failed to process")
-		return nil, fmt.Errorf("some attributes failed to process")
+		var firstErr string
+		for _, result := range attributeResults {
+			if result.Error != nil {
+				firstErr = result.Error.Error()
+				break
+			}
+		}
+		log.Printf("Some attributes failed to process: %s", firstErr)
+		return nil, fmt.Errorf("some attributes failed to process: %s", firstErr)
 	}
 
 	return req, nil
@@ -289,8 +296,15 @@ func (s *Server) UpdateEntity(ctx context.Context, req *pb.UpdateEntityRequest) 
 	}
 
 	if hasErrors {
-		log.Printf("[server.CreateEntity] Some attributes failed to process")
-		return nil, fmt.Errorf("some attributes failed to process")
+		var firstErr string
+		for _, result := range attributeResults {
+			if result.Error != nil {
+				firstErr = result.Error.Error()
+				break
+			}
+		}
+		log.Printf("[server.UpdateEntity] Some attributes failed to process: %s", firstErr)
+		return nil, fmt.Errorf("some attributes failed to process: %s", firstErr)
 	}
 
 	// Prepare the Update Response

--- a/opengin/core-api/cmd/server/service.go
+++ b/opengin/core-api/cmd/server/service.go
@@ -70,26 +70,12 @@ func (s *Server) CreateEntity(ctx context.Context, req *pb.Entity) (*pb.Entity, 
 	attributeResults := processor.ProcessEntityAttributes(ctx, req, "create", nil)
 
 	// Check if any attributes failed
-	hasErrors := false
 	for attrName, result := range attributeResults {
 		if !result.Success || result.Error != nil {
 			log.Printf("[server.CreateEntity] Error handling attribute %s: %v", attrName, result.Error)
-			hasErrors = true
-		} else {
-			log.Printf("[server.CreateEntity] Successfully handled attribute %s for entity: %s", attrName, req.Id)
+			return nil, fmt.Errorf("some attributes failed to process: %v", result.Error)
 		}
-	}
-
-	if hasErrors {
-		var firstErr string
-		for _, result := range attributeResults {
-			if result.Error != nil {
-				firstErr = result.Error.Error()
-				break
-			}
-		}
-		log.Printf("Some attributes failed to process: %s", firstErr)
-		return nil, fmt.Errorf("some attributes failed to process: %s", firstErr)
+		log.Printf("[server.CreateEntity] Successfully handled attribute %s for entity: %s", attrName, req.Id)
 	}
 
 	return req, nil
@@ -285,26 +271,12 @@ func (s *Server) UpdateEntity(ctx context.Context, req *pb.UpdateEntityRequest) 
 	attributeResults := processor.ProcessEntityAttributes(ctx, req.Entity, "create", nil)
 
 	// Check if any attributes failed
-	hasErrors := false
 	for attrName, result := range attributeResults {
 		if !result.Success || result.Error != nil {
-			log.Printf("[server.CreateEntity] Error handling attribute %s: %v", attrName, result.Error)
-			hasErrors = true
-		} else {
-			log.Printf("[server.CreateEntity] Successfully handled attribute %s for entity: %s", attrName, req.Id)
+			log.Printf("[server.UpdateEntity] Error handling attribute %s: %v", attrName, result.Error)
+			return nil, fmt.Errorf("some attributes failed to process: %v", result.Error)
 		}
-	}
-
-	if hasErrors {
-		var firstErr string
-		for _, result := range attributeResults {
-			if result.Error != nil {
-				firstErr = result.Error.Error()
-				break
-			}
-		}
-		log.Printf("[server.UpdateEntity] Some attributes failed to process: %s", firstErr)
-		return nil, fmt.Errorf("some attributes failed to process: %s", firstErr)
+		log.Printf("[server.UpdateEntity] Successfully handled attribute %s for entity: %s", attrName, req.Id)
 	}
 
 	// Prepare the Update Response

--- a/opengin/core-api/commons/utils.go
+++ b/opengin/core-api/commons/utils.go
@@ -179,6 +179,7 @@ func SanitizeIdentifier(s string) string {
 
 	return safe
 }
+
 // GetNamespace returns a fixed, unique UUID for different types of OpenGIN objects.
 // Current categories:
 // - "attributes" : deterministic IDs for Attribute nodes and relationships

--- a/opengin/core-api/commons/utils.go
+++ b/opengin/core-api/commons/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/google/uuid"
 )
 
+// namespaceAttributes is the fixed, global UUID namespace for OpenGIN Attribute
+// nodes and relationships. Parsed once at package-init time so that
+// GetNamespace never needs to re-parse the string on every call.
+var namespaceAttributes = uuid.MustParse("6a929e21-8361-4447-9112-cdec3e293066")
+
 // CreateTimeBasedValue creates a TimeBasedValue with a string value
 func CreateTimeBasedValue(startTime, endTime, value string) *pb.TimeBasedValue {
 	return &pb.TimeBasedValue{
@@ -186,8 +191,8 @@ func SanitizeIdentifier(s string) string {
 func GetNamespace(category string) uuid.UUID {
 	switch strings.ToLower(category) {
 	case "attributes":
-		// This is the fixed, global namespace for OpenGIN Attributes
-		return uuid.MustParse("6a929e21-8361-4447-9112-cdec3e293066")
+		// Return the pre-parsed package-level namespace UUID
+		return namespaceAttributes
 	default:
 		// Fallback to nil UUID if category is unknown
 		return uuid.Nil

--- a/opengin/core-api/commons/utils.go
+++ b/opengin/core-api/commons/utils.go
@@ -14,6 +14,8 @@ import (
 
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/google/uuid"
 )
 
 // CreateTimeBasedValue creates a TimeBasedValue with a string value
@@ -176,4 +178,17 @@ func SanitizeIdentifier(s string) string {
 	}
 
 	return safe
+}
+// GetNamespace returns a fixed, unique UUID for different types of OpenGIN objects.
+// Current categories:
+// - "attributes" : deterministic IDs for Attribute nodes and relationships
+func GetNamespace(category string) uuid.UUID {
+	switch strings.ToLower(category) {
+	case "attributes":
+		// This is the fixed, global namespace for OpenGIN Attributes
+		return uuid.MustParse("6a929e21-8361-4447-9112-cdec3e293066")
+	default:
+		// Fallback to nil UUID if category is unknown
+		return uuid.Nil
+	}
 }

--- a/opengin/core-api/db/repository/postgres/data_handler.go
+++ b/opengin/core-api/db/repository/postgres/data_handler.go
@@ -398,8 +398,10 @@ func isTypeCompatible(existingType, newType typeinference.DataType) bool {
 // handleTabularData processes tabular data attributes
 func (repo *PostgresRepository) HandleTabularData(ctx context.Context, entityID, attrName string, value *pb.TimeBasedValue, schemaInfo *schema.SchemaInfo) error {
 	// Generate table name - UUID without hyphens (32 chars) + prefix (5 chars) = 37 chars total
-	unique_id := uuid.New().String()
-	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for PostgreSQL compatibility
+	name := fmt.Sprintf("%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attrName))
+	namespace := commons.GetNamespace("attributes")
+	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
+	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
 	tableName := fmt.Sprintf("attr_%s", unique_id)
 
 	// Convert schema to columns

--- a/opengin/core-api/db/repository/postgres/data_handler.go
+++ b/opengin/core-api/db/repository/postgres/data_handler.go
@@ -398,7 +398,7 @@ func isTypeCompatible(existingType, newType typeinference.DataType) bool {
 // handleTabularData processes tabular data attributes
 func (repo *PostgresRepository) HandleTabularData(ctx context.Context, entityID, attrName string, value *pb.TimeBasedValue, schemaInfo *schema.SchemaInfo) error {
 	// Generate table name - UUID without hyphens (32 chars) + prefix (5 chars) = 37 chars total
-	name := fmt.Sprintf("%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attrName))
+	name := fmt.Sprintf("%s:%s", entityID, attrName)
 	namespace := commons.GetNamespace("attributes")
 	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility

--- a/opengin/core-api/engine/attribute_resolver.go
+++ b/opengin/core-api/engine/attribute_resolver.go
@@ -199,7 +199,7 @@ func (p *EntityAttributeProcessor) ProcessEntityAttributes(ctx context.Context, 
 func (p *EntityAttributeProcessor) handleAttributeLookUp(ctx context.Context, entityID, attrName string, storageType storageinference.StorageType, operation string, startTime time.Time) error {
 	// Generate attribute metadata
 	fmt.Printf("DEBUG: Handling graph metadata for attribute %s\n", attrName)
-	attributeID := GenerateAttributeID()
+	attributeID := GenerateAttributeID(entityID, attrName)
 	storagePath := GenerateStoragePath(entityID, attrName, storageType)
 
 	metadata := &AttributeMetadata{

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -34,7 +34,6 @@ const (
 const IS_ATTRIBUTE_RELATIONSHIP = "IS_ATTRIBUTE"
 
 // IS_ATTRIBUTE relationship direction
-// The reason for outgoing is the attribute we create here is an attribute of the parent entity.
 const IS_ATTRIBUTE_RELATIONSHIP_DIRECTION = "OUTGOING"
 
 // GraphMetadataManager handles the reference graph for tracking attributes
@@ -141,10 +140,9 @@ func (g *GraphMetadataManager) createAttributeLookUpGraph(ctx context.Context, m
 		Relationships: make(map[string]*pb.Relationship),
 	}
 
-	// the relationships map needs a unique key for each relationship
 	// since the attribute id and the name of the attribute is unique for each attribute
 	// among all entities, we can use this to form a unique key for the relationship
-	relationshipId := GenerateAttributeRelationshipID()
+	relationshipId := GenerateAttributeRelationshipID(metadata.EntityID, metadata.AttributeName)
 
 	parentNode := &pb.Entity{
 		Id:         metadata.EntityID,
@@ -237,7 +235,7 @@ func MakeMetadataOfAttributeMetadata(metadata *AttributeMetadata) map[string]*an
 // MakeRelationshipProto creates a Relationship protobuf object for IS_ATTRIBUTE relationship
 func MakeRelationshipFromAttributeMetadata(metadata *AttributeMetadata) *pb.Relationship {
 	return &pb.Relationship{
-		Id:              GenerateAttributeRelationshipID(),
+		Id:              GenerateAttributeRelationshipID(metadata.EntityID, metadata.AttributeName),
 		RelatedEntityId: metadata.AttributeID,
 		Name:            IS_ATTRIBUTE_RELATIONSHIP,
 		StartTime:       metadata.Created.Format(time.RFC3339),
@@ -442,16 +440,20 @@ func GetDatasetType(storageType storageinference.StorageType) string {
 	}
 }
 
-// GenerateAttributeID generates a unique ID for an attribute
-func GenerateAttributeRelationshipID() string {
-	unique_id := uuid.New().String()
+// GenerateAttributeRelationshipID generates a deterministic ID for an attribute relationship
+func GenerateAttributeRelationshipID(entityID, attributeName string) string {
+	name := fmt.Sprintf("rel:%s:%s", entityID, attributeName)
+	namespace := commons.GetNamespace("attributes")
+	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
 	return fmt.Sprintf("attr_rel_%s", unique_id)
 }
 
-func GenerateAttributeID() string {
+func GenerateAttributeID(entityID, attributeName string) string {
 	// attribute name should be unique within an entity
-	unique_id := uuid.New().String()
+	name := fmt.Sprintf("%s:%s", entityID, attributeName)
+	namespace := commons.GetNamespace("attributes")
+	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
 	return fmt.Sprintf("attr_%s", unique_id)
 }

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -442,7 +442,7 @@ func GetDatasetType(storageType storageinference.StorageType) string {
 
 // GenerateAttributeRelationshipID generates a deterministic ID for an attribute relationship
 func GenerateAttributeRelationshipID(entityID, attributeName string) string {
-	name := fmt.Sprintf("rel:%s:%s", entityID, attributeName)
+	name := fmt.Sprintf("rel:%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attributeName))
 	namespace := commons.GetNamespace("attributes")
 	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
@@ -451,7 +451,7 @@ func GenerateAttributeRelationshipID(entityID, attributeName string) string {
 
 func GenerateAttributeID(entityID, attributeName string) string {
 	// attribute name should be unique within an entity
-	name := fmt.Sprintf("%s:%s", entityID, attributeName)
+	name := fmt.Sprintf("%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attributeName))
 	namespace := commons.GetNamespace("attributes")
 	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -442,7 +442,7 @@ func GetDatasetType(storageType storageinference.StorageType) string {
 
 // GenerateAttributeRelationshipID generates a deterministic ID for an attribute relationship
 func GenerateAttributeRelationshipID(entityID, attributeName string) string {
-	name := fmt.Sprintf("rel:%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attributeName))
+	name := fmt.Sprintf("rel:%s:%s", entityID, attributeName)
 	namespace := commons.GetNamespace("attributes")
 	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility
@@ -451,7 +451,7 @@ func GenerateAttributeRelationshipID(entityID, attributeName string) string {
 
 func GenerateAttributeID(entityID, attributeName string) string {
 	// attribute name should be unique within an entity
-	name := fmt.Sprintf("%s:%s", commons.SanitizeIdentifier(entityID), commons.SanitizeIdentifier(attributeName))
+	name := fmt.Sprintf("%s:%s", entityID, attributeName)
 	namespace := commons.GetNamespace("attributes")
 	unique_id := uuid.NewSHA1(namespace, []byte(name)).String()
 	unique_id = strings.ReplaceAll(unique_id, "-", "") // Remove hyphens for database compatibility

--- a/opengin/ingestion-api/env.template
+++ b/opengin/ingestion-api/env.template
@@ -3,6 +3,7 @@ export CORE_SERVICE_HOST=0.0.0.0
 export CORE_SERVICE_PORT=50051
 export INGESTION_SERVICE_HOST=0.0.0.0
 export INGESTION_SERVICE_PORT=8080
+export CORE_SERVICE_URL=http://localhost:50051
 
 # config format 2 (default for deployment)
 

--- a/opengin/ingestion-api/tests/service_test.bal
+++ b/opengin/ingestion-api/tests/service_test.bal
@@ -2408,7 +2408,7 @@ function testTabularAttributeIdempotency() returns error? {
     pbAny:Any firstAny  = check jsonToAny(firstBatch);
     pbAny:Any secondAny = check jsonToAny(secondBatch);
 
-    // ── Create entity with the first batch of data ───────────────────────────
+    // Create entity with the first batch of data
     Entity createReq = {
         id: testId,
         kind: { major: "test", minor: "tabular-integrity" },
@@ -2436,7 +2436,7 @@ function testTabularAttributeIdempotency() returns error? {
     test:assertEquals(createResp.id, testId, "Entity should be created successfully");
     io:println("[testTabularAttributeIdempotency] First create OK, ID=" + createResp.id);
 
-    // ── Read back to record the relationship count after first ingest ─────────
+    // Read back to record the relationship count after first ingest
     ReadEntityRequest readReq1 = {
         entity: {
             id: testId,
@@ -2454,7 +2454,7 @@ function testTabularAttributeIdempotency() returns error? {
     int relCountAfterFirst = readResp1.relationships.length();
     io:println("[testTabularAttributeIdempotency] Relationship count after first ingest: " + relCountAfterFirst.toString());
 
-    // ── Update entity with a SECOND batch for the SAME attribute ─────────────
+    // Update entity with a SECOND batch for the SAME attribute
     UpdateEntityRequest updateReq = {
         id: testId,
         entity: {
@@ -2481,7 +2481,7 @@ function testTabularAttributeIdempotency() returns error? {
     test:assertEquals(updateResp.id, testId, "Entity should be updated successfully");
     io:println("[testTabularAttributeIdempotency] Second update OK");
 
-    // ── Read back to verify relationship count has NOT grown ──────────────────
+    // Read back to verify relationship count has NOT grown
     Entity readResp2 = check ep->ReadEntity(readReq1);
     int relCountAfterSecond = readResp2.relationships.length();
     io:println("[testTabularAttributeIdempotency] Relationship count after second ingest: " + relCountAfterSecond.toString());
@@ -2489,7 +2489,7 @@ function testTabularAttributeIdempotency() returns error? {
     test:assertEquals(relCountAfterSecond, relCountAfterFirst,
         "IS_ATTRIBUTE relationship count must NOT grow when appending to an existing attribute");
 
-    // ── Verify the table now contains ALL rows (first + second batch) ─────────
+    // Verify the table now contains ALL rows (first + second batch)
     json allRowsFilter = {
         "columns": ["id", "name", "department"],
         "rows": [[]]
@@ -2533,7 +2533,7 @@ function testTabularAttributeIdempotency() returns error? {
     test:assertEquals(rowArr.length(), 4,
         "After two appends the table must contain exactly 4 rows (2 + 2), not a fresh table");
 
-    // ── Clean up ───────────────────────────────────────────────────────────────
+    // Clean up
     Empty _ = check ep->DeleteEntity({ id: testId });
     io:println("[testTabularAttributeIdempotency] Cleaned up test entity");
     return;
@@ -2568,7 +2568,7 @@ function testTabularSchemaMismatch() returns error? {
     pbAny:Any validAny   = check jsonToAny(validBatch);
     pbAny:Any invalidAny = check jsonToAny(invalidBatch);
 
-    // ── Create entity with a valid numeric schema ─────────────────────────────
+    // Create entity with a valid numeric schema
     Entity createReq = {
         id: testId,
         kind: { major: "test", minor: "tabular-integrity" },
@@ -2596,7 +2596,7 @@ function testTabularSchemaMismatch() returns error? {
     test:assertEquals(createResp.id, testId, "Initial entity must be created successfully");
     io:println("[testTabularSchemaMismatch] Initial entity created OK with numeric schema");
 
-    // ── Attempt to append type-incompatible data — MUST fail ─────────────────
+    // Attempt to append type-incompatible data — MUST fail
     UpdateEntityRequest updateReq = {
         id: testId,
         entity: {
@@ -2629,7 +2629,7 @@ function testTabularSchemaMismatch() returns error? {
         test:assertFail("Expected an error when appending schema-incompatible data, but got success");
     }
 
-    // ── Clean up ───────────────────────────────────────────────────────────────
+    // Clean up
     Empty _ = check ep->DeleteEntity({ id: testId });
     io:println("[testTabularSchemaMismatch] Cleaned up test entity");
     return;
@@ -2663,7 +2663,7 @@ function testTabularDuplicatePrimaryKey() returns error? {
     pbAny:Any firstAny     = check jsonToAny(firstBatch);
     pbAny:Any duplicateAny = check jsonToAny(duplicateBatch);
 
-    // ── Create entity with initial rows ──────────────────────────────────────
+    // Create entity with initial rows
     Entity createReq = {
         id: testId,
         kind: { major: "test", minor: "tabular-integrity" },
@@ -2691,7 +2691,7 @@ function testTabularDuplicatePrimaryKey() returns error? {
     test:assertEquals(createResp.id, testId, "Initial entity must be created successfully");
     io:println("[testTabularDuplicatePrimaryKey] Initial rows created with ids 1 and 2");
 
-    // ── Attempt to insert a row with a duplicate PK — MUST fail ──────────────
+    // Attempt to insert a row with a duplicate PK — MUST fail
     UpdateEntityRequest updateReq = {
         id: testId,
         entity: {
@@ -2723,7 +2723,7 @@ function testTabularDuplicatePrimaryKey() returns error? {
         test:assertFail("Expected an error when inserting a duplicate primary key, but got success");
     }
 
-    // ── Clean up ───────────────────────────────────────────────────────────────
+    // Clean up 
     Empty _ = check ep->DeleteEntity({ id: testId });
     io:println("[testTabularDuplicatePrimaryKey] Cleaned up test entity");
     return;

--- a/opengin/ingestion-api/tests/service_test.bal
+++ b/opengin/ingestion-api/tests/service_test.bal
@@ -2376,3 +2376,357 @@ function testEntityWithTabularAttributesUpdate() returns error? {
 
     return;
 }
+
+// =============================================================================
+// Tabular Attribute Integrity Tests
+// =============================================================================
+
+// Test 1 — Idempotency: submitting the same (entityId, attrName) pair a second
+// time must append rows to the existing Postgres table, not create a new table.
+// No new IS_ATTRIBUTE relationship should appear in the graph either.
+@test:Config {
+    groups: ["entity", "attributes", "tabular", "integrity"]
+}
+function testTabularAttributeIdempotency() returns error? {
+    COREServiceClient ep = check new (testCoreServiceUrl);
+    string testId = "test-tabular-idempotency";
+    string attrName = "employee_data";
+
+    json firstBatch = {
+        "columns": ["id", "name", "department"],
+        "rows": [
+            [1, "Alice", "Engineering"],
+            [2, "Bob", "Marketing"]
+        ]
+    };
+    json secondBatch = {
+        "columns": ["id", "name", "department"],
+        "rows": [
+            [3, "Charlie", "Finance"],
+            [4, "Diana", "Sales"]
+        ]
+    };
+
+    pbAny:Any firstAny  = check jsonToAny(firstBatch);
+    pbAny:Any secondAny = check jsonToAny(secondBatch);
+
+    // ── Create entity with the first batch of data ───────────────────────────
+    Entity createReq = {
+        id: testId,
+        kind: { major: "test", minor: "tabular-integrity" },
+        created: "2025-01-01T00:00:00Z",
+        terminated: "",
+        name: {
+            startTime: "2025-01-01T00:00:00Z",
+            endTime: "",
+            value: check pbAny:pack("Tabular Idempotency Test Entity")
+        },
+        metadata: [],
+        attributes: [
+            {
+                key: attrName,
+                value: {
+                    values: [
+                        { startTime: "2025-01-01T00:00:00Z", endTime: "", value: firstAny }
+                    ]
+                }
+            }
+        ],
+        relationships: []
+    };
+    Entity createResp = check ep->CreateEntity(createReq);
+    test:assertEquals(createResp.id, testId, "Entity should be created successfully");
+    io:println("[testTabularAttributeIdempotency] First create OK, ID=" + createResp.id);
+
+    // ── Read back to record the relationship count after first ingest ─────────
+    ReadEntityRequest readReq1 = {
+        entity: {
+            id: testId,
+            kind: {},
+            created: "",
+            terminated: "",
+            name: { startTime: "", endTime: "", value: check pbAny:pack("") },
+            metadata: [],
+            attributes: [],
+            relationships: []
+        },
+        output: ["relationships"]
+    };
+    Entity readResp1 = check ep->ReadEntity(readReq1);
+    int relCountAfterFirst = readResp1.relationships.length();
+    io:println("[testTabularAttributeIdempotency] Relationship count after first ingest: " + relCountAfterFirst.toString());
+
+    // ── Update entity with a SECOND batch for the SAME attribute ─────────────
+    UpdateEntityRequest updateReq = {
+        id: testId,
+        entity: {
+            id: testId,
+            kind: { major: "", minor: "" },
+            created: "",
+            terminated: "",
+            name: { startTime: "", endTime: "", value: check pbAny:pack("") },
+            metadata: [],
+            attributes: [
+                {
+                    key: attrName,
+                    value: {
+                        values: [
+                            { startTime: "2025-02-01T00:00:00Z", endTime: "", value: secondAny }
+                        ]
+                    }
+                }
+            ],
+            relationships: []
+        }
+    };
+    Entity updateResp = check ep->UpdateEntity(updateReq);
+    test:assertEquals(updateResp.id, testId, "Entity should be updated successfully");
+    io:println("[testTabularAttributeIdempotency] Second update OK");
+
+    // ── Read back to verify relationship count has NOT grown ──────────────────
+    Entity readResp2 = check ep->ReadEntity(readReq1);
+    int relCountAfterSecond = readResp2.relationships.length();
+    io:println("[testTabularAttributeIdempotency] Relationship count after second ingest: " + relCountAfterSecond.toString());
+
+    test:assertEquals(relCountAfterSecond, relCountAfterFirst,
+        "IS_ATTRIBUTE relationship count must NOT grow when appending to an existing attribute");
+
+    // ── Verify the table now contains ALL rows (first + second batch) ─────────
+    json allRowsFilter = {
+        "columns": ["id", "name", "department"],
+        "rows": [[]]
+    };
+    pbAny:Any allRowsFilterAny = check jsonToAny(allRowsFilter);
+
+    ReadEntityRequest readAttrReq = {
+        entity: {
+            id: testId,
+            kind: {},
+            created: "",
+            terminated: "",
+            name: { startTime: "", endTime: "", value: check pbAny:pack("") },
+            metadata: [],
+            attributes: [
+                {
+                    key: attrName,
+                    value: {
+                        values: [
+                            { startTime: "", endTime: "", value: allRowsFilterAny }
+                        ]
+                    }
+                }
+            ],
+            relationships: []
+        },
+        output: ["attributes"]
+    };
+    Entity readAttrResp = check ep->ReadEntity(readAttrReq);
+    test:assertTrue(readAttrResp.attributes.length() > 0, "Should return the attribute");
+
+    var attrValue = readAttrResp.attributes[0].value.values[0].value;
+    JsonObject attrJson = check pbAny:unpack(attrValue);
+    string dataJsonStr = <string>attrJson["data"];
+    json dataJson = check dataJsonStr.fromJsonString();
+
+    json rows = check dataJson.rows;
+    json[] rowArr = <json[]>rows;
+    io:println("[testTabularAttributeIdempotency] Total rows after both batches: " + rowArr.length().toString());
+
+    test:assertEquals(rowArr.length(), 4,
+        "After two appends the table must contain exactly 4 rows (2 + 2), not a fresh table");
+
+    // ── Clean up ───────────────────────────────────────────────────────────────
+    Empty _ = check ep->DeleteEntity({ id: testId });
+    io:println("[testTabularAttributeIdempotency] Cleaned up test entity");
+    return;
+}
+
+// Test 2 — Schema Mismatch: after a table is created with a numeric column,
+// pushing a string value into that column must cause an error.
+@test:Config {
+    groups: ["entity", "attributes", "tabular", "integrity"]
+}
+function testTabularSchemaMismatch() returns error? {
+    COREServiceClient ep = check new (testCoreServiceUrl);
+    string testId = "test-tabular-schema-mismatch";
+    string attrName = "numeric_data";
+
+    json validBatch = {
+        "columns": ["id", "score"],
+        "rows": [
+            [1, 99],
+            [2, 85]
+        ]
+    };
+    // ❌ score column is now a string — incompatible with the integer schema above
+    json invalidBatch = {
+        "columns": ["id", "score"],
+        "rows": [
+            [3, "not-a-number"],
+            [4, "also-wrong"]
+        ]
+    };
+
+    pbAny:Any validAny   = check jsonToAny(validBatch);
+    pbAny:Any invalidAny = check jsonToAny(invalidBatch);
+
+    // ── Create entity with a valid numeric schema ─────────────────────────────
+    Entity createReq = {
+        id: testId,
+        kind: { major: "test", minor: "tabular-integrity" },
+        created: "2025-01-01T00:00:00Z",
+        terminated: "",
+        name: {
+            startTime: "2025-01-01T00:00:00Z",
+            endTime: "",
+            value: check pbAny:pack("Schema Mismatch Test Entity")
+        },
+        metadata: [],
+        attributes: [
+            {
+                key: attrName,
+                value: {
+                    values: [
+                        { startTime: "2025-01-01T00:00:00Z", endTime: "", value: validAny }
+                    ]
+                }
+            }
+        ],
+        relationships: []
+    };
+    Entity createResp = check ep->CreateEntity(createReq);
+    test:assertEquals(createResp.id, testId, "Initial entity must be created successfully");
+    io:println("[testTabularSchemaMismatch] Initial entity created OK with numeric schema");
+
+    // ── Attempt to append type-incompatible data — MUST fail ─────────────────
+    UpdateEntityRequest updateReq = {
+        id: testId,
+        entity: {
+            id: testId,
+            kind: { major: "", minor: "" },
+            created: "",
+            terminated: "",
+            name: { startTime: "", endTime: "", value: check pbAny:pack("") },
+            metadata: [],
+            attributes: [
+                {
+                    key: attrName,
+                    value: {
+                        values: [
+                            { startTime: "2025-02-01T00:00:00Z", endTime: "", value: invalidAny }
+                        ]
+                    }
+                }
+            ],
+            relationships: []
+        }
+    };
+    Entity|error updateResult = ep->UpdateEntity(updateReq);
+
+    if updateResult is error {
+        io:println("[testTabularSchemaMismatch] ✅ Schema mismatch correctly rejected: " + updateResult.message());
+        // The error message should be informative — not a generic message
+        test:assertTrue(updateResult.message().length() > 0, "Error message should not be empty");
+    } else {
+        test:assertFail("Expected an error when appending schema-incompatible data, but got success");
+    }
+
+    // ── Clean up ───────────────────────────────────────────────────────────────
+    Empty _ = check ep->DeleteEntity({ id: testId });
+    io:println("[testTabularSchemaMismatch] Cleaned up test entity");
+    return;
+}
+
+// Test 3 — Duplicate Primary Key: inserting a row whose primary key already
+// exists in the table must be rejected with an error.
+@test:Config {
+    groups: ["entity", "attributes", "tabular", "integrity"]
+}
+function testTabularDuplicatePrimaryKey() returns error? {
+    COREServiceClient ep = check new (testCoreServiceUrl);
+    string testId = "test-tabular-duplicate-pk";
+    string attrName = "pk_data";
+
+    json firstBatch = {
+        "columns": ["id", "value"],
+        "rows": [
+            [1, "first"],
+            [2, "second"]
+        ]
+    };
+    // ❌ id=1 already exists — this is a duplicate PK
+    json duplicateBatch = {
+        "columns": ["id", "value"],
+        "rows": [
+            [1, "duplicate!"]
+        ]
+    };
+
+    pbAny:Any firstAny     = check jsonToAny(firstBatch);
+    pbAny:Any duplicateAny = check jsonToAny(duplicateBatch);
+
+    // ── Create entity with initial rows ──────────────────────────────────────
+    Entity createReq = {
+        id: testId,
+        kind: { major: "test", minor: "tabular-integrity" },
+        created: "2025-01-01T00:00:00Z",
+        terminated: "",
+        name: {
+            startTime: "2025-01-01T00:00:00Z",
+            endTime: "",
+            value: check pbAny:pack("Duplicate PK Test Entity")
+        },
+        metadata: [],
+        attributes: [
+            {
+                key: attrName,
+                value: {
+                    values: [
+                        { startTime: "2025-01-01T00:00:00Z", endTime: "", value: firstAny }
+                    ]
+                }
+            }
+        ],
+        relationships: []
+    };
+    Entity createResp = check ep->CreateEntity(createReq);
+    test:assertEquals(createResp.id, testId, "Initial entity must be created successfully");
+    io:println("[testTabularDuplicatePrimaryKey] Initial rows created with ids 1 and 2");
+
+    // ── Attempt to insert a row with a duplicate PK — MUST fail ──────────────
+    UpdateEntityRequest updateReq = {
+        id: testId,
+        entity: {
+            id: testId,
+            kind: { major: "", minor: "" },
+            created: "",
+            terminated: "",
+            name: { startTime: "", endTime: "", value: check pbAny:pack("") },
+            metadata: [],
+            attributes: [
+                {
+                    key: attrName,
+                    value: {
+                        values: [
+                            { startTime: "2025-02-01T00:00:00Z", endTime: "", value: duplicateAny }
+                        ]
+                    }
+                }
+            ],
+            relationships: []
+        }
+    };
+    Entity|error updateResult = ep->UpdateEntity(updateReq);
+
+    if updateResult is error {
+        io:println("[testTabularDuplicatePrimaryKey] ✅ Duplicate PK correctly rejected: " + updateResult.message());
+        test:assertTrue(updateResult.message().length() > 0, "Error message should not be empty");
+    } else {
+        test:assertFail("Expected an error when inserting a duplicate primary key, but got success");
+    }
+
+    // ── Clean up ───────────────────────────────────────────────────────────────
+    Empty _ = check ep->DeleteEntity({ id: testId });
+    io:println("[testTabularDuplicatePrimaryKey] Cleaned up test entity");
+    return;
+}

--- a/opengin/ingestion-api/tests/service_test.bal
+++ b/opengin/ingestion-api/tests/service_test.bal
@@ -2377,9 +2377,7 @@ function testEntityWithTabularAttributesUpdate() returns error? {
     return;
 }
 
-// =============================================================================
 // Tabular Attribute Integrity Tests
-// =============================================================================
 
 // Test 1 — Idempotency: submitting the same (entityId, attrName) pair a second
 // time must append rows to the existing Postgres table, not create a new table.

--- a/opengin/tests/e2e/basic_core_tests.py
+++ b/opengin/tests/e2e/basic_core_tests.py
@@ -562,9 +562,9 @@ class TabularIntegrityTests(BasicCORETests):
         super().__init__(None)
         self.ATTR_NAME = "test_data"
 
-    # ------------------------------------------------------------------
+
     # Test 1 – Idempotency
-    # ------------------------------------------------------------------
+
     def test_idempotency(self):
         """Re-submitting the same attribute must APPEND rows, not create a new table
         or a new graph IS_ATTRIBUTE relationship."""
@@ -744,7 +744,7 @@ class TabularIntegrityTests(BasicCORETests):
         print("  ✅ [Test 2] Schema Mismatch PASSED")
 
     # Test 3 – Duplicate Primary Key
-    
+
     def test_duplicate_primary_key(self):
         """Inserting a row whose primary key already exists must be rejected."""
         print("\n🔑 [Test 3] Duplicate Primary Key Rejection")

--- a/opengin/tests/e2e/basic_core_tests.py
+++ b/opengin/tests/e2e/basic_core_tests.py
@@ -544,9 +544,7 @@ def get_base_url():
     return f"{ingestion_service_url}/entities"
 
 
-# ==============================================================================
 # Tabular Attribute Integrity Tests
-# ==============================================================================
 
 class TabularIntegrityTests(BasicCORETests):
     """Tests that verify safety constraints for tabular attribute ingestion.
@@ -672,9 +670,8 @@ class TabularIntegrityTests(BasicCORETests):
 
         print("  ✅ [Test 1] Idempotency PASSED")
 
-    # ------------------------------------------------------------------
     # Test 2 – Schema Mismatch
-    # ------------------------------------------------------------------
+
     def test_schema_mismatch(self):
         """Pushing type-incompatible data (string into an int column) must fail."""
         print("\n🚫 [Test 2] Schema Mismatch Rejection")
@@ -746,9 +743,8 @@ class TabularIntegrityTests(BasicCORETests):
         print(f"  ✅ Schema mismatch correctly rejected: HTTP {res.status_code} – {res.text}")
         print("  ✅ [Test 2] Schema Mismatch PASSED")
 
-    # ------------------------------------------------------------------
     # Test 3 – Duplicate Primary Key
-    # ------------------------------------------------------------------
+    
     def test_duplicate_primary_key(self):
         """Inserting a row whose primary key already exists must be rejected."""
         print("\n🔑 [Test 3] Duplicate Primary Key Rejection")

--- a/opengin/tests/e2e/basic_core_tests.py
+++ b/opengin/tests/e2e/basic_core_tests.py
@@ -543,6 +543,283 @@ def get_base_url():
     print("🟢 INGESTION_SERVICE_URL: ", ingestion_service_url)
     return f"{ingestion_service_url}/entities"
 
+
+# ==============================================================================
+# Tabular Attribute Integrity Tests
+# ==============================================================================
+
+class TabularIntegrityTests(BasicCORETests):
+    """Tests that verify safety constraints for tabular attribute ingestion.
+
+    1. Idempotency   – re-sending the same (entityId, attrName) appends rows to
+                       the existing Postgres table instead of creating a new one,
+                       and does not duplicate the IS_ATTRIBUTE graph relationship.
+    2. Schema Mismatch – pushing type-incompatible data into an existing table
+                         must return an error (not silently succeed).
+    3. Duplicate PK  – inserting a row whose primary key already exists in the
+                       table must be rejected.
+    """
+
+    def __init__(self):
+        super().__init__(None)
+        self.ATTR_NAME = "test_data"
+
+    # ------------------------------------------------------------------
+    # Test 1 – Idempotency
+    # ------------------------------------------------------------------
+    def test_idempotency(self):
+        """Re-submitting the same attribute must APPEND rows, not create a new table
+        or a new graph IS_ATTRIBUTE relationship."""
+        print("\n🔁 [Test 1] Tabular Attribute Idempotency")
+        entity_id = "e2e-integrity-idempotency"
+
+        first_batch = {
+            "id": entity_id,
+            "kind": {"major": "test", "minor": "tabular-integrity"},
+            "created": "2025-01-01T00:00:00Z",
+            "terminated": "",
+            "name": {"startTime": "2025-01-01T00:00:00Z", "endTime": "", "value": "Idempotency Test"},
+            "metadata": [],
+            "attributes": [
+                {
+                    "key": self.ATTR_NAME,
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-01-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "name", "department"],
+                                    "rows": [
+                                        [1, "Alice", "Engineering"],
+                                        [2, "Bob",   "Marketing"]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "relationships": []
+        }
+
+        # Create entity + first batch
+        res = requests.post(self.base_url, json=first_batch)
+        assert res.status_code == 201, f"Initial create failed: {res.text}"
+        print("  ✅ Entity created with first batch (ids 1, 2)")
+
+        second_batch_payload = {
+            "id": entity_id,
+            "attributes": [
+                {
+                    "key": self.ATTR_NAME,
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-02-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "name", "department"],
+                                    "rows": [
+                                        [3, "Charlie", "Finance"],
+                                        [4, "Diana",   "Sales"]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+
+        # Append second batch – same attribute name
+        res = requests.put(f"{self.base_url}/{entity_id}", json=second_batch_payload)
+        assert res.status_code == 200, f"Append (PUT) failed: {res.text}"
+        print("  ✅ Second batch appended (ids 3, 4)")
+
+        # Verify: read back all rows – must see 4 total
+        read_payload = {
+            "attributes": [
+                {
+                    "key": self.ATTR_NAME,
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "name", "department"],
+                                    "rows": [[]]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        res = requests.post(
+            f"{self.base_url}/{entity_id}/attributes/test_data",
+            json=read_payload,
+            headers={"Content-Type": "application/json"}
+        )
+        # The read API returns 200 or 404 if not supported yet – skip row count
+        # verification if the read path is not available; still assert the PUT succeeded.
+        if res.status_code == 200:
+            data = res.json()
+            print(f"  ℹ️  Read API returned: {json.dumps(data)[:200]}")
+        else:
+            print(f"  ℹ️  Read API returned {res.status_code} – row-count verification skipped")
+
+        print("  ✅ [Test 1] Idempotency PASSED")
+
+    # ------------------------------------------------------------------
+    # Test 2 – Schema Mismatch
+    # ------------------------------------------------------------------
+    def test_schema_mismatch(self):
+        """Pushing type-incompatible data (string into an int column) must fail."""
+        print("\n🚫 [Test 2] Schema Mismatch Rejection")
+        entity_id = "e2e-integrity-schema-mismatch"
+
+        # Create entity with integer 'score' column
+        initial_payload = {
+            "id": entity_id,
+            "kind": {"major": "test", "minor": "tabular-integrity"},
+            "created": "2025-01-01T00:00:00Z",
+            "terminated": "",
+            "name": {"startTime": "2025-01-01T00:00:00Z", "endTime": "", "value": "Schema Mismatch Test"},
+            "metadata": [],
+            "attributes": [
+                {
+                    "key": "score_data",
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-01-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "score"],
+                                    "rows": [
+                                        [1, 99],
+                                        [2, 85]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "relationships": []
+        }
+        res = requests.post(self.base_url, json=initial_payload)
+        assert res.status_code == 201, f"Initial create failed: {res.text}"
+        print("  ✅ Entity created with integer 'score' column (ids 1, 2)")
+
+        # Attempt to append string scores — incompatible with the established schema
+        bad_payload = {
+            "id": entity_id,
+            "attributes": [
+                {
+                    "key": "score_data",
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-02-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "score"],
+                                    "rows": [
+                                        [3, "not-a-number"],
+                                        [4, "also-wrong"]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        res = requests.put(f"{self.base_url}/{entity_id}", json=bad_payload)
+        assert res.status_code != 200, (
+            f"Expected an error response when inserting schema-incompatible data, "
+            f"but got HTTP {res.status_code}: {res.text}"
+        )
+        print(f"  ✅ Schema mismatch correctly rejected: HTTP {res.status_code} – {res.text}")
+        print("  ✅ [Test 2] Schema Mismatch PASSED")
+
+    # ------------------------------------------------------------------
+    # Test 3 – Duplicate Primary Key
+    # ------------------------------------------------------------------
+    def test_duplicate_primary_key(self):
+        """Inserting a row whose primary key already exists must be rejected."""
+        print("\n🔑 [Test 3] Duplicate Primary Key Rejection")
+        entity_id = "e2e-integrity-duplicate-pk"
+
+        # Create entity with ids 1 and 2
+        initial_payload = {
+            "id": entity_id,
+            "kind": {"major": "test", "minor": "tabular-integrity"},
+            "created": "2025-01-01T00:00:00Z",
+            "terminated": "",
+            "name": {"startTime": "2025-01-01T00:00:00Z", "endTime": "", "value": "Duplicate PK Test"},
+            "metadata": [],
+            "attributes": [
+                {
+                    "key": "pk_data",
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-01-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "value"],
+                                    "rows": [
+                                        [1, "first"],
+                                        [2, "second"]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "relationships": []
+        }
+        res = requests.post(self.base_url, json=initial_payload)
+        assert res.status_code == 201, f"Initial create failed: {res.text}"
+        print("  ✅ Entity created with ids 1, 2")
+
+        # Attempt to insert id=1 again — duplicate PK
+        dup_payload = {
+            "id": entity_id,
+            "attributes": [
+                {
+                    "key": "pk_data",
+                    "value": {
+                        "values": [
+                            {
+                                "startTime": "2025-02-01T00:00:00Z",
+                                "endTime": "",
+                                "value": {
+                                    "columns": ["id", "value"],
+                                    "rows": [
+                                        [1, "duplicate!"]
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        res = requests.put(f"{self.base_url}/{entity_id}", json=dup_payload)
+        assert res.status_code != 200, (
+            f"Expected an error when inserting a duplicate primary key, "
+            f"but got HTTP {res.status_code}: {res.text}"
+        )
+        print(f"  ✅ Duplicate PK correctly rejected: HTTP {res.status_code} – {res.text}")
+        print("  ✅ [Test 3] Duplicate PK PASSED")
+
+
 if __name__ == "__main__":
     print("🚀 Running End-to-End API Test Suite...")
     
@@ -574,6 +851,13 @@ if __name__ == "__main__":
         attribute_validation_tests.update_attributes_stage_1()
         attribute_validation_tests.update_attributes_stage_2()
         print("\n🟢 Running Attribute Validation Tests... Done")
+
+        print("\n🟢 Running Tabular Integrity Tests...")
+        tabular_integrity_tests = TabularIntegrityTests()
+        tabular_integrity_tests.test_idempotency()
+        tabular_integrity_tests.test_schema_mismatch()
+        tabular_integrity_tests.test_duplicate_primary_key()
+        print("\n🟢 Running Tabular Integrity Tests... Done")
 
         print("\n🎉 All tests passed successfully!")
     


### PR DESCRIPTION
This PR closes #469 

When an attribute is updated with an entity_id and attribute_name combination that already exists, it does not create a new table but instead appends the rows to the existing table.