### PR TITLE
chore: rename mongodb client functions from [CRUD]Entity to [CRUD]Metadata

### DIFF
--- a/opengin/core-api/cmd/server/service.go
+++ b/opengin/core-api/cmd/server/service.go
@@ -304,14 +304,14 @@ func (s *Server) DeleteEntity(ctx context.Context, req *pb.EntityId) (*pb.Empty,
 	log.Printf("[server.DeleteEntity] Deleting Entity metadata: %s", req.Id)
 
 	// Check if entity exists before deleting
-	_, err := s.mongoRepo.ReadEntity(ctx, req.Id)
+	_, err := s.mongoRepo.ReadMetadata(ctx, req.Id)
 	if err != nil {
 		// NOTE: Not returning an error here because we want to delete the
 		// entity even if it does not contain metadata
 		log.Printf("[server.DeleteEntity] Entity %s does not contain metadata: %v", req.Id, err)
 	} else {
 		log.Printf("[server.DeleteEntity] Entity %s metadata exists.", req.Id)
-		_, err = s.mongoRepo.DeleteEntity(ctx, req.Id)
+		_, err = s.mongoRepo.DeleteMetadata(ctx, req.Id)
 		if err != nil {
 			// Log error
 			log.Printf("[server.DeleteEntity] Error deleting metadata for entity %s: %v", req.Id, err)

--- a/opengin/core-api/cmd/server/service.go
+++ b/opengin/core-api/cmd/server/service.go
@@ -303,7 +303,7 @@ func (s *Server) UpdateEntity(ctx context.Context, req *pb.UpdateEntityRequest) 
 func (s *Server) DeleteEntity(ctx context.Context, req *pb.EntityId) (*pb.Empty, error) {
 	log.Printf("[server.DeleteEntity] Deleting Entity metadata: %s", req.Id)
 
-	// Check if entity exists before deleting
+	// Check if metadata exists before deleting
 	_, err := s.mongoRepo.ReadMetadata(ctx, req.Id)
 	if err != nil {
 		// NOTE: Not returning an error here because we want to delete the

--- a/opengin/core-api/db/repository/mongo/metadata_handler.go
+++ b/opengin/core-api/db/repository/mongo/metadata_handler.go
@@ -23,7 +23,7 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 	}
 
 	// Check if metadata for entity already exists
-	existingEntity, err := repo.ReadEntity(ctx, entityId)
+	existingEntity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil && err != mongo.ErrNoDocuments {
 		return err
 	}
@@ -40,12 +40,12 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 			Attributes:    entity.Attributes,
 			Relationships: entity.Relationships,
 		}
-		_, err = repo.CreateEntity(ctx, newEntity)
+		_, err = repo.CreateMetadata(ctx, newEntity)
 	} else {
 		// Update existing entity's metadata
 		// TODO: Should we choose _id for placing our id or should we use id field separately and use that.
 		// Because then it is going to be reading or deleting or whatever by filtering using an attribute not the id of the object.
-		_, err = repo.UpdateEntity(ctx, existingEntity.Id, bson.M{"metadata": entity.GetMetadata()})
+		_, err = repo.UpdateMetadata(ctx, existingEntity.Id, bson.M{"metadata": entity.GetMetadata()})
 	}
 
 	return err
@@ -53,8 +53,8 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 
 // Improved GetMetadata function that handles conversion internally
 func (repo *MongoRepository) GetMetadata(ctx context.Context, entityId string) (map[string]*anypb.Any, error) {
-	// Use the existing ReadEntity method for consistency
-	entity, err := repo.ReadEntity(ctx, entityId)
+	// Use the existing method for consistency
+	entity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil {
 		// Log error and return empty metadata map
 		log.Printf("Error retrieving metadata for entity %s: %v", entityId, err)

--- a/opengin/core-api/db/repository/mongo/metadata_handler.go
+++ b/opengin/core-api/db/repository/mongo/metadata_handler.go
@@ -53,7 +53,7 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 
 // Improved GetMetadata function that handles conversion internally
 func (repo *MongoRepository) GetMetadata(ctx context.Context, entityId string) (map[string]*anypb.Any, error) {
-	// Use the existing method for consistency
+// Use the existing ReadMetadata method for consistency
 	entity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil {
 		// Log error and return empty metadata map

--- a/opengin/core-api/db/repository/mongo/metadata_handler.go
+++ b/opengin/core-api/db/repository/mongo/metadata_handler.go
@@ -53,7 +53,7 @@ func (repo *MongoRepository) HandleMetadata(ctx context.Context, entityId string
 
 // Improved GetMetadata function that handles conversion internally
 func (repo *MongoRepository) GetMetadata(ctx context.Context, entityId string) (map[string]*anypb.Any, error) {
-// Use the existing ReadMetadata method for consistency
+	// Use the existing ReadMetadata method for consistency
 	entity, err := repo.ReadMetadata(ctx, entityId)
 	if err != nil {
 		// Log error and return empty metadata map

--- a/opengin/core-api/db/repository/mongo/mongodb_client.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client.go
@@ -74,17 +74,17 @@ func (repo *MongoRepository) collection() *mongo.Collection {
 	return repo.client.Database(repo.config.DBName).Collection(repo.config.Collection)
 }
 
-// CreateEntity inserts a new entity in MongoDB
+// CreateMetadata inserts a new entity in MongoDB
 // FIXME: https://github.com/LDFLK/nexoan/issues/118
-func (repo *MongoRepository) CreateEntity(ctx context.Context, entity *pb.Entity) (*mongo.InsertOneResult, error) {
+func (repo *MongoRepository) CreateMetadata(ctx context.Context, entity *pb.Entity) (*mongo.InsertOneResult, error) {
 	// Use the entity.Id as MongoDB's _id field
 	doc := toDocument(entity)
 	result, err := repo.collection().InsertOne(ctx, doc)
 	return result, err
 }
 
-// ReadEntity fetches an entity by ID from MongoDB
-func (repo *MongoRepository) ReadEntity(ctx context.Context, id string) (*pb.Entity, error) {
+// ReadMetadata fetches an entity by ID from MongoDB
+func (repo *MongoRepository) ReadMetadata(ctx context.Context, id string) (*pb.Entity, error) {
 	var doc entityDocument
 	err := repo.collection().FindOne(ctx, bson.M{"_id": id}).Decode(&doc)
 	if err != nil {
@@ -93,15 +93,15 @@ func (repo *MongoRepository) ReadEntity(ctx context.Context, id string) (*pb.Ent
 	return fromDocument(&doc), nil
 }
 
-// UpdateEntity updates an entity's attributes in MongoDB
-func (repo *MongoRepository) UpdateEntity(ctx context.Context, id string, updates bson.M) (*mongo.UpdateResult, error) {
+// UpdateMetadata updates an entity's attributes in MongoDB
+func (repo *MongoRepository) UpdateMetadata(ctx context.Context, id string, updates bson.M) (*mongo.UpdateResult, error) {
 	update := bson.M{"$set": updates}
 	result, err := repo.collection().UpdateOne(ctx, bson.M{"_id": id}, update)
 	return result, err
 }
 
-// DeleteEntity removes an entity from MongoDB
-func (repo *MongoRepository) DeleteEntity(ctx context.Context, id string) (*mongo.DeleteResult, error) {
+// DeleteMetadata removes an entity from MongoDB
+func (repo *MongoRepository) DeleteMetadata(ctx context.Context, id string) (*mongo.DeleteResult, error) {
 	result, err := repo.collection().DeleteOne(ctx, bson.M{"_id": id})
 	return result, err
 }

--- a/opengin/core-api/db/repository/mongo/mongodb_client.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client.go
@@ -74,7 +74,7 @@ func (repo *MongoRepository) collection() *mongo.Collection {
 	return repo.client.Database(repo.config.DBName).Collection(repo.config.Collection)
 }
 
-// CreateMetadata inserts a new entity in MongoDB
+// CreateMetadata inserts new metadata in MongoDB
 // FIXME: https://github.com/LDFLK/nexoan/issues/118
 func (repo *MongoRepository) CreateMetadata(ctx context.Context, entity *pb.Entity) (*mongo.InsertOneResult, error) {
 	// Use the entity.Id as MongoDB's _id field

--- a/opengin/core-api/db/repository/mongo/mongodb_client.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client.go
@@ -100,7 +100,7 @@ func (repo *MongoRepository) UpdateMetadata(ctx context.Context, id string, upda
 	return result, err
 }
 
-// DeleteMetadata removes an entity from MongoDB
+// DeleteMetadata removes metadata from MongoDB
 func (repo *MongoRepository) DeleteMetadata(ctx context.Context, id string) (*mongo.DeleteResult, error) {
 	result, err := repo.collection().DeleteOne(ctx, bson.M{"_id": id})
 	return result, err

--- a/opengin/core-api/db/repository/mongo/mongodb_client.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client.go
@@ -93,7 +93,7 @@ func (repo *MongoRepository) ReadMetadata(ctx context.Context, id string) (*pb.E
 	return fromDocument(&doc), nil
 }
 
-// UpdateMetadata updates an entity's attributes in MongoDB
+// UpdateMetadata updates metadata in MongoDB
 func (repo *MongoRepository) UpdateMetadata(ctx context.Context, id string, updates bson.M) (*mongo.UpdateResult, error) {
 	update := bson.M{"$set": updates}
 	result, err := repo.collection().UpdateOne(ctx, bson.M{"_id": id}, update)

--- a/opengin/core-api/db/repository/mongo/mongodb_client.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client.go
@@ -83,7 +83,7 @@ func (repo *MongoRepository) CreateMetadata(ctx context.Context, entity *pb.Enti
 	return result, err
 }
 
-// ReadMetadata fetches an entity by ID from MongoDB
+// ReadMetadata fetches metadata by ID from MongoDB
 func (repo *MongoRepository) ReadMetadata(ctx context.Context, id string) (*pb.Entity, error) {
 	var doc entityDocument
 	err := repo.collection().FindOne(ctx, bson.M{"_id": id}).Decode(&doc)

--- a/opengin/core-api/db/repository/mongo/mongodb_client_test.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client_test.go
@@ -95,19 +95,19 @@ func TestCreateAndReadEntity(t *testing.T) {
 		Metadata: metadata,
 	}
 
-	// Create entity
+	// Create metadata
 	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 	log.Printf("Inserted document with ID: %v", result.InsertedID)
 
-	// Read entity with error check
+	// Read metadata with error check
 	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	if err != nil {
-		t.Fatalf("Failed to read entity: %v", err)
+		t.Fatalf("Failed to read metadata: %v", err)
 	}
 	if readEntity == nil {
-		t.Fatal("Entity not found after creation")
+		t.Fatal("Metadata not found after creation")
 	}
 
 	// Verify entity data
@@ -145,7 +145,7 @@ func TestUpdateEntityMetadata(t *testing.T) {
 		Metadata: metadata,
 	}
 
-	// Create entity
+	// Create metadata
 	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
@@ -158,13 +158,13 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	updatedMetadata["key1"] = val2 // Update existing key
 	updatedMetadata["key3"] = val3 // Add new key
 
-	// Update entity
+	// Update metadata
 	_, err = testRepo.UpdateMetadata(testCtx, entityID, map[string]interface{}{
 		"metadata": updatedMetadata,
 	})
 	assert.NoError(t, err)
 
-	// Read updated entity
+	// Read updated metadata
 	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 
@@ -200,18 +200,18 @@ func TestDeleteEntity(t *testing.T) {
 		Metadata: metadata,
 	}
 
-	// Create entity
+	// Create metadata
 	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
-	// Delete entity
+	// Delete metadata
 	result, err := testRepo.DeleteMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), result.DeletedCount)
 
-	// Verify entity is deleted
+	// Verify metadata is deleted
 	_, err = testRepo.ReadMetadata(testCtx, entityID)
-	assert.Error(t, err) // Should return an error since entity doesn't exist
+	assert.Error(t, err) // Should return an error since metadata doesn't exist
 }
 
 // TestMetadataHandling verifies the handling of complex metadata with various data types:
@@ -249,12 +249,12 @@ func TestMetadataHandling(t *testing.T) {
 		Metadata: metadata,
 	}
 
-	// Create entity - this should use the entityID as the document ID
+	// Create metadata - this should use the entityID as the document ID
 	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 
-	// Read entity to verify metadata was stored correctly
+	// Read metadata to verify it was stored correctly
 	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 

--- a/opengin/core-api/db/repository/mongo/mongodb_client_test.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client_test.go
@@ -67,13 +67,13 @@ func TestMain(m *testing.M) {
 	os.Exit(exitCode)
 }
 
-// TestCreateAndReadEntity verifies the entity creation and reading functionality:
-// 1. Creates an entity with test metadata
-// 2. Confirms the entity exists in the database after creation
-// 3. Reads the entity and verifies the metadata values
-// 4. Validates that the entity ID is correctly set
+// TestCreateAndReadMetadata verifies the metadata creation and reading functionality:
+// 1. Creates a metadata document with test values
+// 2. Confirms the metadata exists in the database after creation
+// 3. Reads the metadata and verifies the values
+// 4. Validates that the document ID (entity ID) is correctly set
 // 5. Confirms the metadata values are stored correctly
-func TestCreateAndReadEntity(t *testing.T) {
+func TestCreateAndReadMetadata(t *testing.T) {
 	// Log database and collection information
 	log.Printf("Test using database: %s, collection: %s", testRepo.GetDBName(), testRepo.GetCollectionName())
 
@@ -119,14 +119,13 @@ func TestCreateAndReadEntity(t *testing.T) {
 	assert.Contains(t, readEntity.Metadata, "key2")
 }
 
-// TestUpdateEntityMetadata verifies the metadata update functionality:
-// 1. Creates an entity with initial metadata
+// TestUpdateMetadata verifies the metadata update functionality:
+// 1. Creates initial metadata for a document
 // 2. Updates the metadata with new values
-// 3. Reads the updated entity and verifies the metadata changes
+// 3. Reads the updated metadata and verifies the changes
 // 4. Confirms that the metadata values are updated correctly
-// 5. Validates that the entity ID remains unchanged
-// TestUpdateEntityMetadata tests updating entity metadata
-func TestUpdateEntityMetadata(t *testing.T) {
+// 5. Validates that the document ID remains unchanged
+func TestUpdateMetadata(t *testing.T) {
 	// Log database and collection information
 	log.Printf("Test using database: %s, collection: %s", testRepo.GetDBName(), testRepo.GetCollectionName())
 
@@ -174,14 +173,14 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	assert.Contains(t, readEntity.Metadata, "key3")
 }
 
-// TestDeleteEntity verifies the entity deletion functionality:
-// 1. Creates an entity with test metadata
-// 2. Confirms the entity exists in the database after creation
-// 3. Tests the DeleteEntity method by removing the entity
+// TestDeleteMetadata verifies the metadata deletion functionality:
+// 1. Creates a metadata document with test values
+// 2. Confirms the metadata exists in the database after creation
+// 3. Tests the DeleteMetadata method by removing the document
 // 4. Verifies that exactly one document was deleted (DeletedCount = 1)
-// 5. Confirms the entity no longer exists by attempting to read it
-// 6. Validates that an error is returned when trying to read a deleted entity
-func TestDeleteEntity(t *testing.T) {
+// 5. Confirms the metadata no longer exists by attempting to read it
+// 6. Validates that an error is returned when trying to read deleted metadata
+func TestDeleteMetadata(t *testing.T) {
 	// Log database and collection information
 	log.Printf("Test using database: %s, collection: %s", testRepo.GetDBName(), testRepo.GetCollectionName())
 

--- a/opengin/core-api/db/repository/mongo/mongodb_client_test.go
+++ b/opengin/core-api/db/repository/mongo/mongodb_client_test.go
@@ -96,13 +96,13 @@ func TestCreateAndReadEntity(t *testing.T) {
 	}
 
 	// Create entity
-	result, err := testRepo.CreateEntity(testCtx, entity)
+	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 	log.Printf("Inserted document with ID: %v", result.InsertedID)
 
 	// Read entity with error check
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	if err != nil {
 		t.Fatalf("Failed to read entity: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	}
 
 	// Create entity
-	_, err = testRepo.CreateEntity(testCtx, entity)
+	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
 	// Update metadata
@@ -159,13 +159,13 @@ func TestUpdateEntityMetadata(t *testing.T) {
 	updatedMetadata["key3"] = val3 // Add new key
 
 	// Update entity
-	_, err = testRepo.UpdateEntity(testCtx, entityID, map[string]interface{}{
+	_, err = testRepo.UpdateMetadata(testCtx, entityID, map[string]interface{}{
 		"metadata": updatedMetadata,
 	})
 	assert.NoError(t, err)
 
 	// Read updated entity
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 
 	// Verify updated metadata
@@ -201,16 +201,16 @@ func TestDeleteEntity(t *testing.T) {
 	}
 
 	// Create entity
-	_, err = testRepo.CreateEntity(testCtx, entity)
+	_, err = testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 
 	// Delete entity
-	result, err := testRepo.DeleteEntity(testCtx, entityID)
+	result, err := testRepo.DeleteMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), result.DeletedCount)
 
 	// Verify entity is deleted
-	_, err = testRepo.ReadEntity(testCtx, entityID)
+	_, err = testRepo.ReadMetadata(testCtx, entityID)
 	assert.Error(t, err) // Should return an error since entity doesn't exist
 }
 
@@ -250,12 +250,12 @@ func TestMetadataHandling(t *testing.T) {
 	}
 
 	// Create entity - this should use the entityID as the document ID
-	result, err := testRepo.CreateEntity(testCtx, entity)
+	result, err := testRepo.CreateMetadata(testCtx, entity)
 	assert.NoError(t, err)
 	assert.NotNil(t, result, "Insert result should not be nil")
 
 	// Read entity to verify metadata was stored correctly
-	readEntity, err := testRepo.ReadEntity(testCtx, entityID)
+	readEntity, err := testRepo.ReadMetadata(testCtx, entityID)
 	assert.NoError(t, err)
 
 	// Verify metadata with different value types

--- a/opengin/core-api/engine/graph_metadata_manager.go
+++ b/opengin/core-api/engine/graph_metadata_manager.go
@@ -220,12 +220,12 @@ func (g *GraphMetadataManager) createAttributeLookUpGraph(ctx context.Context, m
 	}
 
 	// Check if the attribute metadata already exists
-	existingMetadata, err := mongoRepository.ReadEntity(ctx, metadata.AttributeID)
+	existingMetadata, err := mongoRepository.ReadMetadata(ctx, metadata.AttributeID)
 	if err == nil && existingMetadata != nil {
 		log.Printf("[GraphMetadataManager.CreateAttribute] Attribute metadata already exists: %s, skipping creation", metadata.AttributeID)
 	} else {
 		// Metadata doesn't exist, create it
-		_, err = mongoRepository.CreateEntity(ctx, attributeNode)
+		_, err = mongoRepository.CreateMetadata(ctx, attributeNode)
 		if err != nil {
 			log.Printf("[GraphMetadataManager.CreateAttribute] Error creating attribute metadata: %v", err)
 			return err
@@ -341,7 +341,7 @@ func (g *GraphMetadataManager) GetAttribute(ctx context.Context, entityID string
 		log.Printf("[GraphMetadataManager.GetAttribute] Error getting Mongo repository: %v", err)
 		return nil, err
 	}
-	attributeMetadataEntity, err := mongoRepository.ReadEntity(ctx, targetAttributeID)
+	attributeMetadataEntity, err := mongoRepository.ReadMetadata(ctx, targetAttributeID)
 	if err != nil {
 		log.Printf("[GraphMetadataManager.GetAttribute] Error getting attribute metadata from MongoDB for attribute %s (entity %s): %v", targetAttributeID, entityID, err)
 		return nil, fmt.Errorf("failed to get attribute metadata from MongoDB for attribute %s (entity %s): %w", targetAttributeID, entityID, err)
@@ -417,7 +417,7 @@ func (g *GraphMetadataManager) ListAttributes(ctx context.Context, entityID stri
 			log.Printf("[GraphMetadataManager.ListAttributes] Error getting Mongo repository: %v", err)
 			return nil, err
 		}
-		attributeMetadataEntity, err := mongoRepository.ReadEntity(ctx, attributeID)
+		attributeMetadataEntity, err := mongoRepository.ReadMetadata(ctx, attributeID)
 		if err != nil {
 			log.Printf("[GraphMetadataManager.ListAttributes] Error getting attribute metadata from MongoDB for attribute %s (entity %s): %v", attributeID, entityID, err)
 			return nil, fmt.Errorf("failed to get attribute metadata from MongoDB for attribute %s (entity %s): %w", attributeID, entityID, err)


### PR DESCRIPTION
# summary

renames the crud operations for mongodb from using entity to metadata, as they were in reality updating the metadata instead of the entity it self, and updates any references that was using the functions that was renamed.

# validation

```bash
cd opengin/core-api/db/repository/mongo
go test .
```

---

fixes: #340
