### PR TITLE
fix(docker): replace deprecated dbms.* neo4j settings with server.* (#398)

### DIFF
--- a/deployment/development/docker/neo4j/Dockerfile
+++ b/deployment/development/docker/neo4j/Dockerfile
@@ -6,16 +6,16 @@ FROM neo4j:5.12.0
 
 # Set environment variables
 ENV NEO4J_AUTH=neo4j/neo4j123
-ENV NEO4J_dbms_memory_pagecache_size=512M
-ENV NEO4J_dbms_memory_heap_initial__size=512M
-ENV NEO4J_dbms_memory_heap_max__size=512M
+ENV NEO4J_server_memory_pagecache_size=512M
+ENV NEO4J_server_memory_heap_initial__size=512M
+ENV NEO4J_server_memory_heap_max__size=512M
 ENV NEO4J_dbms_security_procedures_unrestricted=gds.*,apoc.*
 
 # Set data directory paths
-ENV NEO4J_dbms_directories_data=/neo4j_data
-ENV NEO4J_dbms_directories_logs=/neo4j_logs
-ENV NEO4J_dbms_directories_import=/var/lib/neo4j/import
-ENV NEO4J_dbms_directories_plugins=/neo4j_plugins
+ENV NEO4J_server_directories_data=/neo4j_data
+ENV NEO4J_server_directories_logs=/neo4j_logs
+ENV NEO4J_server_directories_import=/var/lib/neo4j/import
+ENV NEO4J_server_directories_plugins=/neo4j_plugins
 
 # Expose ports
 EXPOSE 7474 7687

--- a/deployment/development/docker/neo4j/Dockerfile
+++ b/deployment/development/docker/neo4j/Dockerfile
@@ -9,7 +9,7 @@ ENV NEO4J_AUTH=neo4j/neo4j123
 ENV NEO4J_server_memory_pagecache_size=512M
 ENV NEO4J_server_memory_heap_initial__size=512M
 ENV NEO4J_server_memory_heap_max__size=512M
-ENV NEO4J_dbms_security_procedures_unrestricted=gds.*,apoc.*
+ENV NEO4J_server_security_procedures_unrestricted=gds.*,apoc.*
 
 # Set data directory paths
 ENV NEO4J_server_directories_data=/neo4j_data

--- a/deployment/development/docker/neo4j/Dockerfile
+++ b/deployment/development/docker/neo4j/Dockerfile
@@ -9,7 +9,7 @@ ENV NEO4J_AUTH=neo4j/neo4j123
 ENV NEO4J_server_memory_pagecache_size=512M
 ENV NEO4J_server_memory_heap_initial__size=512M
 ENV NEO4J_server_memory_heap_max__size=512M
-ENV NEO4J_server_security_procedures_unrestricted=gds.*,apoc.*
+ENV NEO4J_dbms_security_procedures_unrestricted=gds.*,apoc.*
 
 # Set data directory paths
 ENV NEO4J_server_directories_data=/neo4j_data


### PR DESCRIPTION
## Summary

Neo4j 5.x emits 7 deprecation warnings on every startup of the dev Neo4j container because `deployment/development/docker/neo4j/Dockerfile` still passes the legacy `NEO4J_dbms_*` environment variables. This PR renames them to the new `server.*` namespace, matching the convention already used in `deployment/choreo/development/docker/neo4j/Dockerfile`.

### Changes

- `NEO4J_dbms_memory_pagecache_size` → `NEO4J_server_memory_pagecache_size`
- `NEO4J_dbms_memory_heap_initial__size` → `NEO4J_server_memory_heap_initial__size`
- `NEO4J_dbms_memory_heap_max__size` → `NEO4J_server_memory_heap_max__size`
- `NEO4J_dbms_directories_data` → `NEO4J_server_directories_data`
- `NEO4J_dbms_directories_logs` → `NEO4J_server_directories_logs`
- `NEO4J_dbms_directories_import` → `NEO4J_server_directories_import`
- `NEO4J_dbms_directories_plugins` → `NEO4J_server_directories_plugins`

`NEO4J_dbms_security_procedures_unrestricted` is intentionally left as-is — the `dbms.security.*` namespace was **not** renamed in Neo4j 5, and the original issue's log did not flag it.

Fixes #398

---
_Prepared with AI assistance (Claude Code); reviewed by me before pushing._